### PR TITLE
docs: add multi-language readme translations

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,205 @@
+# Prism - Software de traducción con IA
+
+<div align="center">
+
+**[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Tiếng Việt](./README.vi.md)**
+
+🚀 Una potente aplicación de traducción multiplataforma impulsada por modelos de lenguaje avanzados y tecnología OCR.
+
+[Descarga](#descarga) • [Funciones](#funciones) • [Inicio-rápido](#inicio-rápido) • [Documentación](#documentación)
+
+</div>
+
+---
+<img src="icon.png" alt="Icono" width="350" height="350">
+
+## Funciones
+
+- **🌍 Compatibilidad multiplataforma** - Soporte completo para Windows, macOS y Linux con las mismas funciones
+- **🤖 Traducción IA avanzada** - Basado en el modelo Tencent Hunyuan-MT-7B para traducciones precisas con contexto
+- **📸 OCR integrado** - Extrae y traduce texto directamente desde capturas con Qwen3-VL-8B-Instruct
+- **⚡ Traducción ultrarrápida** - Traducción en tiempo real con latencia mínima
+- **🎯 Interfaz fácil de usar** - UI intuitiva en Vue 3 con interacciones fluidas
+- **🔗 Atajos globales** - Atajos personalizables para acceso rápido (en desarrollo)
+- **💾 Historial local** - Almacena traducciones en SQLite de forma local
+- **🎨 Arquitectura moderna** - Construido con Tauri + Rust para máximo rendimiento y seguridad
+
+---
+
+## Stack tecnológico
+
+### Frontend
+
+- **Vue 3** (3.5.13) - Framework JavaScript progresivo y moderno
+- **Vite** (6.0.3) - Herramienta de build de nueva generación
+- **Componentes UI de Tauri** - Experiencia nativa en escritorio
+
+### Backend
+
+- **Rust** (edición 2021) - Lenguaje de sistemas de alto rendimiento
+- **Tauri** (2.9.3) - Framework ligero para apps de escritorio
+- **Tokio** (1.48.0) - Runtime asíncrono para concurrencia
+
+### IA y procesamiento
+
+- **Modelo de traducción** - Tencent Hunyuan-MT-7B
+- **Modelo de OCR** - Qwen3-VL-8B-Instruct
+- **Proveedor API** - SiliconFlow
+- **Compatibilidad completa con APIs tipo OpenAI para modelos personalizados**
+
+### Almacenamiento y librerías
+
+- **SQLite** (rusqlite 0.37.0) - Base de datos local
+- **Reqwest** (0.12.24) - Cliente HTTP
+- **Procesamiento de imágenes** (0.25.9) - Capturas y manipulación de imágenes
+- **Atajos globales** (2.3.1) - Plugin de atajos de teclado
+
+---
+
+## Inicio-rápido
+
+### Requisitos previos
+
+- Rust 1.91.0 o superior
+- Node.js 18+ y pnpm
+- Git
+
+### Instalación
+
+**1. Clonar el repositorio**
+```bash
+git clone https://github.com/qyzhg/prism.git
+cd prism
+```
+
+**2. Instalar dependencias**
+#### Dependencias frontend
+```bash
+pnpm install
+```
+
+#### Dependencias Rust gestionadas por Cargo
+
+**3. Obtener API Key**
+- Usa tu propia URL base compatible con OpenAI y tu API key para empezar.
+- Regístrate en SiliconFlow con nuestro enlace de invitación: [https://cloud.siliconflow.cn/i/QhM7Qyuq](https://cloud.siliconflow.cn/i/QhM7Qyuq) y consigue créditos gratuitos (larga validez).
+
+**4. Ejecutar en modo desarrollo**
+```bash
+pnpm tauri dev
+```
+
+**5. Compilar para producción**
+```bash
+pnpm tauri build
+```
+
+---
+
+## Descarga
+
+| Plataforma | Enlace |
+|-----------|--------|
+| 🪟 Windows | [Última versión](https://github.com/qyzhg/prism/releases) |
+| 🍎 macOS | [Última versión](https://github.com/qyzhg/prism/releases) |
+| 🐧 Linux | Próximamente |
+
+### Notas de instalación en macOS
+
+Prism está firmado ad-hoc (los certificados Developer ID son de pago), por lo que Gatekeeper mostrará una advertencia la primera vez.
+
+1. Mueve `Prism.app` a `/Applications`.
+2. Abre **Terminal** y ejecuta:
+   ```bash
+   xattr -cr /Applications/prism.app
+   sudo spctl --add --label Prism /Applications/prism.app
+   ```
+3. Haz clic derecho en la app, elige **Open** y confirma una vez. Las próximas ejecuciones serán normales.
+
+---
+
+## Documentación
+
+### Configuración
+
+Gestiona tus preferencias en el panel de ajustes:
+
+- Selección de idioma origen/destino por defecto
+- Gestión de API keys
+- Personalización de atajos (en desarrollo)
+
+### Atajos
+
+En desarrollo - Próximamente
+
+### Modelos de IA
+
+- **Modelo de traducción** - `tencent/Hunyuan-MT-7B` traducción multilingüe empresarial
+- **Modelo de OCR** - `Qwen/Qwen3-VL-8B-Instruct` visión-lenguaje avanzada
+
+---
+
+## Hoja de ruta
+
+- [x] Funcionalidad básica de traducción
+- [x] Integración de OCR por captura
+- [x] Configuración de atajos personalizados
+- [ ] Memoria de traducción y gestión de glosarios
+- [ ] Traducción por lotes de archivos
+- [ ] Ecosistema de plugins
+- [ ] App complementaria móvil
+
+---
+
+## Preguntas frecuentes (FAQ)
+
+**P: ¿Puedo usarlo gratis?**  
+R: Sí. Regístrate en SiliconFlow con nuestro enlace para obtener créditos gratuitos suficientes para uso prolongado.
+
+**P: ¿Qué idiomas se soportan?**  
+R: El modelo Tencent Hunyuan-MT-7B cubre varios idiomas principales (chino, inglés, japonés, coreano y más). También puedes usar el modelo que prefieras.
+
+**P: ¿Se guarda mi información?**  
+R: El historial de traducción se guarda localmente en SQLite y nunca se sube a servidores. Tu privacidad está protegida.
+
+**P: ¿Puedo usarlo sin conexión?**  
+R: Los modelos en línea requieren conexión. Con modelos locales, el uso sin conexión es posible.
+
+**P: ¿Cuándo estarán listos los atajos?**  
+R: La función de atajos está en desarrollo y llegará pronto.
+
+---
+
+## Contribuir
+
+Se aceptan Issues y Pull Requests. ¡Tus contribuciones son bienvenidas!
+
+---
+
+## Licencia
+
+Proyecto bajo licencia MIT - consulta [LICENSE](LICENSE) para más detalles.
+
+---
+
+## Agradecimientos
+
+- Construido con [Tauri](https://tauri.app/)
+- Servicios de traducción durante el desarrollo proporcionados por [SiliconFlow](https://siliconflow.cn/)
+- UI basada en [Vue 3](https://vuejs.org/)
+
+---
+
+## Ayuda
+
+- 🐛 Reporte de bugs: [GitHub Issues](https://github.com/qyzhg/prism/issues)
+
+---
+
+<div align="center">
+
+❤️ Desarrollado por el equipo Prism@pity
+
+**[⬆ Volver arriba](#prism---software-de-traducción-con-ia)**
+
+</div>

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,205 @@
+# Prism - AI翻訳ソフトウェア
+
+<div align="center">
+
+**[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Tiếng Việt](./README.vi.md)**
+
+🚀 先進的な言語モデルとOCRを搭載したクロスプラットフォームAI翻訳アプリ。
+
+[ダウンロード](#ダウンロード) • [機能](#機能) • [クイックスタート](#クイックスタート) • [ドキュメント](#ドキュメント)
+
+</div>
+
+---
+<img src="icon.png" alt="アイコン" width="350" height="350">
+
+## 機能
+
+- **🌍 クロスプラットフォーム対応** - Windows / macOS / Linux で同等の機能を提供
+- **🤖 高度なAI翻訳** - Tencent Hunyuan-MT-7B を採用し、文脈を考慮した正確な翻訳
+- **📸 内蔵OCR** - Qwen3-VL-8B-Instruct でスクリーンショットから直接テキスト抽出・翻訳
+- **⚡ 高速翻訳** - リアルタイムかつ低遅延
+- **🎯 使いやすいUI** - Vue 3 ベースの直感的でスムーズなUI
+- **🔗 グローバルホットキー** - カスタマイズ可能なショートカット（開発中）
+- **💾 ローカル履歴** - SQLite に翻訳履歴を保存
+- **🎨 モダンなアーキテクチャ** - Tauri + Rust による高性能かつ安全な構成
+
+---
+
+## 技術スタック
+
+### フロントエンド
+
+- **Vue 3** (3.5.13) - 近代的なプログレッシブフレームワーク
+- **Vite** (6.0.3) - 次世代ビルドツール
+- **Tauri UI コンポーネント** - ネイティブに近いデスクトップ体験
+
+### バックエンド
+
+- **Rust** (2021 edition) - 高性能システム言語
+- **Tauri** (2.9.3) - 軽量デスクトップフレームワーク
+- **Tokio** (1.48.0) - 非同期ランタイム
+
+### AI と処理
+
+- **翻訳モデル** - Tencent Hunyuan-MT-7B
+- **OCRモデル** - Qwen3-VL-8B-Instruct
+- **APIプロバイダ** - SiliconFlow
+- **OpenAI互換のカスタムモデルを幅広くサポート**
+
+### ストレージとライブラリ
+
+- **SQLite** (rusqlite 0.37.0) - ローカルデータベース
+- **Reqwest** (0.12.24) - HTTPクライアント
+- **画像処理** (0.25.9) - スクリーンショットと画像処理
+- **グローバルホットキー** (2.3.1) - キーボードショートカットプラグイン
+
+---
+
+## クイックスタート
+
+### 必要環境
+
+- Rust 1.91.0 以上
+- Node.js 18+ と pnpm
+- Git
+
+### セットアップ
+
+**1. リポジトリをクローン**
+```bash
+git clone https://github.com/qyzhg/prism.git
+cd prism
+```
+
+**2. 依存関係をインストール**
+#### フロントエンド依存
+```bash
+pnpm install
+```
+
+#### Rust 依存は Cargo が管理
+
+**3. API キーを取得**
+- OpenAI 互換の Base URL と API Key を用意すれば利用開始できます。
+- 招待リンクから SiliconFlow に登録すると無料クレジットが得られます: [https://cloud.siliconflow.cn/i/QhM7Qyuq](https://cloud.siliconflow.cn/i/QhM7Qyuq)
+
+**4. 開発モードで起動**
+```bash
+pnpm tauri dev
+```
+
+**5. 本番ビルド**
+```bash
+pnpm tauri build
+```
+
+---
+
+## ダウンロード
+
+| プラットフォーム | リンク |
+|----------------|-------|
+| 🪟 Windows | [最新版](https://github.com/qyzhg/prism/releases) |
+| 🍎 macOS | [最新版](https://github.com/qyzhg/prism/releases) |
+| 🐧 Linux | 近日対応 |
+
+### macOS インストールメモ
+
+Prism は ad-hoc 署名のため、初回起動時に Gatekeeper の警告が表示されます。
+
+1. `Prism.app` を `/Applications` に移動。
+2. **Terminal** で以下を実行:
+   ```bash
+   xattr -cr /Applications/prism.app
+   sudo spctl --add --label Prism /Applications/prism.app
+   ```
+3. Finder で右クリック（または Control+クリック）し **開く** を選択して一度承認すれば、次回以降は通常起動できます。
+
+---
+
+## ドキュメント
+
+### 設定
+
+設定パネルで翻訳の好みを管理できます:
+
+- デフォルトの言語ペア選択
+- API キー管理
+- ホットキーのカスタマイズ（開発中）
+
+### ホットキー
+
+開発中 - 近日公開
+
+### AI モデル
+
+- **翻訳モデル** - `tencent/Hunyuan-MT-7B` エンタープライズ向け多言語翻訳
+- **OCRモデル** - `Qwen/Qwen3-VL-8B-Instruct` 高度なビジョン・ランゲージ
+
+---
+
+## ロードマップ
+
+- [x] 基本の翻訳機能
+- [x] スクリーンショットOCR統合
+- [x] カスタムホットキー設定
+- [ ] 翻訳メモリと用語管理
+- [ ] ファイルのバッチ翻訳
+- [ ] プラグインエコシステム
+- [ ] モバイル連携アプリ
+
+---
+
+## FAQ
+
+**Q: 無料で使えますか？**  
+はい。招待リンク経由で SiliconFlow に登録すると、長期間使える無料クレジットがもらえます。
+
+**Q: どの言語に対応していますか？**  
+Tencent Hunyuan-MT-7B は主要言語（中国語・英語・日本語・韓国語など）の相互翻訳に対応しています。好みのモデルを使うことも可能です。
+
+**Q: データは保存されますか？**  
+翻訳履歴はローカルの SQLite に保存され、サーバーへは送信されません。プライバシーは保護されます。
+
+**Q: オフラインで使えますか？**  
+オンラインモデルは接続が必須です。ローカルモデルを利用する場合はオフラインも可能です。
+
+**Q: ホットキーはいつ使えますか？**  
+現在開発中で、近日リリース予定です。
+
+---
+
+## コントリビュート
+
+Issue と Pull Request を歓迎します。ぜひ貢献してください！
+
+---
+
+## ライセンス
+
+MIT ライセンスです。詳細は [LICENSE](LICENSE) を参照してください。
+
+---
+
+## 謝辞
+
+- [Tauri](https://tauri.app/) によって構築
+- 開発中の翻訳サービスは [SiliconFlow](https://siliconflow.cn/) 提供
+- UI フレームワークは [Vue 3](https://vuejs.org/)
+
+---
+
+## サポート
+
+- 🐛 バグ報告: [GitHub Issues](https://github.com/qyzhg/prism/issues)
+
+---
+
+<div align="center">
+
+❤️ Prism チーム@pity による開発
+
+**[⬆ トップに戻る](#prism---ai翻訳ソフトウェア)**
+
+</div>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,205 @@
+# Prism - AI 번역 소프트웨어
+
+<div align="center">
+
+**[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Tiếng Việt](./README.vi.md)**
+
+🚀 고급 언어 모델과 OCR 기술로 구동되는 강력한 크로스플랫폼 AI 번역 애플리케이션.
+
+[다운로드](#다운로드) • [기능](#기능) • [빠른-시작](#빠른-시작) • [문서](#문서)
+
+</div>
+
+---
+<img src="icon.png" alt="아이콘" width="350" height="350">
+
+## 기능
+
+- **🌍 크로스플랫폼 지원** - Windows, macOS, Linux 모두 동일한 기능 제공
+- **🤖 고급 AI 번역** - Tencent Hunyuan-MT-7B 기반의 문맥 인지 번역
+- **📸 내장 OCR** - Qwen3-VL-8B-Instruct로 스크린샷에서 텍스트 추출 및 번역
+- **⚡ 초고속 번역** - 실시간, 저지연 번역
+- **🎯 직관적 UI** - Vue 3 기반의 부드러운 인터페이스
+- **🔗 글로벌 핫키** - 커스텀 가능한 단축키(개발 중)
+- **💾 로컬 기록** - SQLite에 번역 내역 저장
+- **🎨 현대적 아키텍처** - Tauri + Rust로 높은 성능과 보안
+
+---
+
+## 기술 스택
+
+### 프론트엔드
+
+- **Vue 3** (3.5.13) - 현대적 프로그레시브 프레임워크
+- **Vite** (6.0.3) - 차세대 빌드 도구
+- **Tauri UI 컴포넌트** - 네이티브급 데스크톱 경험
+
+### 백엔드
+
+- **Rust** (2021 edition) - 고성능 시스템 언어
+- **Tauri** (2.9.3) - 경량 데스크톱 프레임워크
+- **Tokio** (1.48.0) - 비동기 런타임
+
+### AI 및 처리
+
+- **번역 모델** - Tencent Hunyuan-MT-7B
+- **OCR 모델** - Qwen3-VL-8B-Instruct
+- **API 제공자** - SiliconFlow
+- **OpenAI 호환 커스텀 모델 완전 지원**
+
+### 저장소 및 라이브러리
+
+- **SQLite** (rusqlite 0.37.0) - 로컬 데이터베이스
+- **Reqwest** (0.12.24) - HTTP 클라이언트
+- **이미지 처리** (0.25.9) - 스크린샷 및 이미지 처리
+- **글로벌 핫키** (2.3.1) - 키보드 단축키 플러그인
+
+---
+
+## 빠른 시작
+
+### 필요 환경
+
+- Rust 1.91.0 이상
+- Node.js 18+ 및 pnpm
+- Git
+
+### 설치
+
+**1. 리포지토리 클론**
+```bash
+git clone https://github.com/qyzhg/prism.git
+cd prism
+```
+
+**2. 의존성 설치**
+#### 프론트엔드 의존성
+```bash
+pnpm install
+```
+
+#### Rust 의존성은 Cargo가 관리
+
+**3. API Key 준비**
+- OpenAI 호환 Base URL과 API Key를 입력하면 바로 사용 가능.
+- 초대 링크로 SiliconFlow 가입 시 무료 크레딧 제공: [https://cloud.siliconflow.cn/i/QhM7Qyuq](https://cloud.siliconflow.cn/i/QhM7Qyuq)
+
+**4. 개발 모드 실행**
+```bash
+pnpm tauri dev
+```
+
+**5. 프로덕션 빌드**
+```bash
+pnpm tauri build
+```
+
+---
+
+## 다운로드
+
+| 플랫폼 | 링크 |
+|-------|------|
+| 🪟 Windows | [최신 버전](https://github.com/qyzhg/prism/releases) |
+| 🍎 macOS | [최신 버전](https://github.com/qyzhg/prism/releases) |
+| 🐧 Linux | 곧 제공 |
+
+### macOS 설치 메모
+
+Prism는 ad-hoc 서명으로 배포되므로 첫 실행 시 Gatekeeper 경고가 뜰 수 있습니다.
+
+1. `Prism.app`을 `/Applications`로 이동합니다.
+2. **Terminal**에서 다음을 실행:
+   ```bash
+   xattr -cr /Applications/prism.app
+   sudo spctl --add --label Prism /Applications/prism.app
+   ```
+3. Finder에서 우클릭(또는 Control+클릭) 후 **Open**을 선택해 한 번 허용하면 이후엔 정상 실행됩니다.
+
+---
+
+## 문서
+
+### 설정
+
+설정 패널에서 다음을 관리할 수 있습니다:
+
+- 기본 언어 쌍 선택
+- API Key 관리
+- 단축키 커스터마이즈(개발 중)
+
+### 핫키
+
+개발 중 - 곧 제공
+
+### AI 모델
+
+- **번역 모델** - `tencent/Hunyuan-MT-7B` 엔터프라이즈 다국어 번역
+- **OCR 모델** - `Qwen/Qwen3-VL-8B-Instruct` 고급 비전-언어 모델
+
+---
+
+## 로드맵
+
+- [x] 핵심 번역 기능
+- [x] 스크린샷 OCR 통합
+- [x] 커스텀 단축키 설정
+- [ ] 번역 메모리 및 용어집
+- [ ] 파일 일괄 번역
+- [ ] 플러그인 생태계
+- [ ] 모바일 동반 앱
+
+---
+
+## 자주 묻는 질문(FAQ)
+
+**Q: 무료로 사용할 수 있나요?**  
+네. SiliconFlow 초대 링크로 가입하면 장기간 쓸 수 있는 무료 크레딧을 받을 수 있습니다.
+
+**Q: 어떤 언어를 지원하나요?**  
+Tencent Hunyuan-MT-7B는 중국어, 영어, 일본어, 한국어 등 주요 언어의 상호 번역을 지원합니다. 원하는 모델을 선택해도 됩니다.
+
+**Q: 데이터가 저장되나요?**  
+번역 기록은 로컬 SQLite에 저장되며 서버로 전송되지 않습니다. 개인정보는 보호됩니다.
+
+**Q: 오프라인 사용이 가능한가요?**  
+온라인 모델은 연결이 필요합니다. 로컬 모델을 사용하면 오프라인도 가능합니다.
+
+**Q: 핫키는 언제쯤 사용 가능한가요?**  
+현재 개발 중이며 곧 제공될 예정입니다.
+
+---
+
+## 기여
+
+Issue와 Pull Request를 환영합니다. 기여를 기다립니다!
+
+---
+
+## 라이선스
+
+MIT 라이선스. 자세한 내용은 [LICENSE](LICENSE) 참고.
+
+---
+
+## 감사의 말
+
+- [Tauri](https://tauri.app/)로 제작
+- 개발 중 번역 서비스는 [SiliconFlow](https://siliconflow.cn/) 제공
+- UI 프레임워크는 [Vue 3](https://vuejs.org/)
+
+---
+
+## 도움말
+
+- 🐛 버그 신고: [GitHub Issues](https://github.com/qyzhg/prism/issues)
+
+---
+
+<div align="center">
+
+❤️ Prism 팀@pity 개발
+
+**[⬆ 맨 위로](#prism---ai-번역-소프트웨어)**
+
+</div>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**[English](./README.md) | [中文](./README.zh.md)**
+**[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Tiếng Việt](./README.vi.md)**
 
 🚀 A powerful cross-platform AI translation application powered by advanced language models and OCR technology.
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,205 @@
+# Prism - Phần mềm dịch thuật AI
+
+<div align="center">
+
+**[English](./README.md) | [中文](./README.zh.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Tiếng Việt](./README.vi.md)**
+
+🚀 Ứng dụng dịch đa nền tảng mạnh mẽ, sử dụng mô hình ngôn ngữ tiên tiến và công nghệ OCR.
+
+[Tải xuống](#tải-xuống) • [Tính-năng](#tính-năng) • [Bắt-đầu-nhanh](#bắt-đầu-nhanh) • [Tài-liệu](#tài-liệu)
+
+</div>
+
+---
+<img src="icon.png" alt="Biểu tượng" width="350" height="350">
+
+## Tính năng
+
+- **🌍 Đa nền tảng** - Hỗ trợ đầy đủ Windows, macOS và Linux với chức năng thống nhất
+- **🤖 Dịch AI nâng cao** - Dựa trên Tencent Hunyuan-MT-7B cho dịch thuật chính xác theo ngữ cảnh
+- **📸 OCR tích hợp** - Trích xuất và dịch văn bản trực tiếp từ ảnh chụp màn hình với Qwen3-VL-8B-Instruct
+- **⚡ Tốc độ cao** - Dịch thời gian thực với độ trễ tối thiểu
+- **🎯 Giao diện thân thiện** - UI trực quan trên Vue 3 với trải nghiệm mượt mà
+- **🔗 Phím tắt toàn cục** - Tùy chỉnh phím tắt (đang phát triển)
+- **💾 Lịch sử cục bộ** - Lưu lịch sử dịch trong SQLite
+- **🎨 Kiến trúc hiện đại** - Xây dựng bằng Tauri + Rust cho hiệu năng và bảo mật cao
+
+---
+
+## Công nghệ
+
+### Frontend
+
+- **Vue 3** (3.5.13) - Framework JavaScript hiện đại
+- **Vite** (6.0.3) - Công cụ build thế hệ mới
+- **Thành phần UI Tauri** - Trải nghiệm ứng dụng desktop gần gũi native
+
+### Backend
+
+- **Rust** (2021 edition) - Ngôn ngữ hệ thống hiệu năng cao
+- **Tauri** (2.9.3) - Framework desktop nhẹ
+- **Tokio** (1.48.0) - Runtime bất đồng bộ
+
+### AI & xử lý
+
+- **Mô hình dịch** - Tencent Hunyuan-MT-7B
+- **Mô hình OCR** - Qwen3-VL-8B-Instruct
+- **Nhà cung cấp API** - SiliconFlow
+- **Hỗ trợ đầy đủ API tương thích OpenAI cho mô hình tùy chỉnh**
+
+### Lưu trữ & thư viện
+
+- **SQLite** (rusqlite 0.37.0) - CSDL cục bộ
+- **Reqwest** (0.12.24) - HTTP client
+- **Xử lý ảnh** (0.25.9) - Chụp và xử lý ảnh
+- **Phím tắt toàn cục** (2.3.1) - Plugin phím tắt
+
+---
+
+## Bắt đầu nhanh
+
+### Yêu cầu
+
+- Rust 1.91.0 trở lên
+- Node.js 18+ và pnpm
+- Git
+
+### Cài đặt
+
+**1. Nhân bản kho mã**
+```bash
+git clone https://github.com/qyzhg/prism.git
+cd prism
+```
+
+**2. Cài phụ thuộc**
+#### Phụ thuộc frontend
+```bash
+pnpm install
+```
+
+#### Phụ thuộc Rust được quản lý bởi Cargo
+
+**3. Lấy API Key**
+- Dùng Base URL tương thích OpenAI và API Key của bạn để bắt đầu.
+- Đăng ký SiliconFlow qua link mời để nhận tín dụng miễn phí: [https://cloud.siliconflow.cn/i/QhM7Qyuq](https://cloud.siliconflow.cn/i/QhM7Qyuq)
+
+**4. Chạy chế độ phát triển**
+```bash
+pnpm tauri dev
+```
+
+**5. Build bản sản xuất**
+```bash
+pnpm tauri build
+```
+
+---
+
+## Tải xuống
+
+| Nền tảng | Liên kết |
+|---------|----------|
+| 🪟 Windows | [Bản mới nhất](https://github.com/qyzhg/prism/releases) |
+| 🍎 macOS | [Bản mới nhất](https://github.com/qyzhg/prism/releases) |
+| 🐧 Linux | Sắp ra mắt |
+
+### Ghi chú cài đặt macOS
+
+Prism dùng chữ ký ad-hoc (không có chứng chỉ Developer ID trả phí), nên Gatekeeper sẽ cảnh báo ở lần mở đầu tiên.
+
+1. Di chuyển `Prism.app` vào `/Applications`.
+2. Mở **Terminal** và chạy:
+   ```bash
+   xattr -cr /Applications/prism.app
+   sudo spctl --add --label Prism /Applications/prism.app
+   ```
+3. Nhấp chuột phải vào app, chọn **Open** và xác nhận một lần. Những lần sau mở bình thường.
+
+---
+
+## Tài liệu
+
+### Cấu hình
+
+Quản lý tùy chỉnh trong bảng cài đặt:
+
+- Chọn cặp ngôn ngữ mặc định
+- Quản lý API Key
+- Tùy chỉnh phím tắt (đang phát triển)
+
+### Phím tắt
+
+Đang phát triển - Sẽ sớm có
+
+### Mô hình AI
+
+- **Mô hình dịch** - `tencent/Hunyuan-MT-7B` dịch đa ngôn ngữ cấp doanh nghiệp
+- **Mô hình OCR** - `Qwen/Qwen3-VL-8B-Instruct` thị giác-ngôn ngữ nâng cao
+
+---
+
+## Lộ trình
+
+- [x] Chức năng dịch cốt lõi
+- [x] Tích hợp OCR cho ảnh chụp màn hình
+- [x] Cấu hình phím tắt tùy chỉnh
+- [ ] Bộ nhớ dịch và quản lý thuật ngữ
+- [ ] Dịch hàng loạt tệp
+- [ ] Hệ sinh thái plugin
+- [ ] Ứng dụng di động đi kèm
+
+---
+
+## Câu hỏi thường gặp (FAQ)
+
+**Hỏi: Có dùng miễn phí được không?**  
+Có. Đăng ký SiliconFlow qua link mời để nhận tín dụng miễn phí đủ dùng lâu dài.
+
+**Hỏi: Hỗ trợ những ngôn ngữ nào?**  
+Tencent Hunyuan-MT-7B hỗ trợ nhiều ngôn ngữ chính (Trung, Anh, Nhật, Hàn...). Bạn cũng có thể dùng mô hình ưa thích.
+
+**Hỏi: Dữ liệu có được lưu lại không?**  
+Lịch sử dịch lưu cục bộ trong SQLite và không tải lên máy chủ. Quyền riêng tư được bảo vệ.
+
+**Hỏi: Có dùng offline được không?**  
+Mô hình online cần kết nối. Nếu dùng mô hình cục bộ, có thể làm việc offline.
+
+**Hỏi: Khi nào có phím tắt?**  
+Đang phát triển và sẽ phát hành sớm.
+
+---
+
+## Đóng góp
+
+Chào đón Issue và Pull Request. Rất mong đóng góp của bạn!
+
+---
+
+## Giấy phép
+
+Phần mềm theo giấy phép MIT - xem [LICENSE](LICENSE) để biết chi tiết.
+
+---
+
+## Lời cảm ơn
+
+- Xây dựng với [Tauri](https://tauri.app/)
+- Dịch vụ dịch trong quá trình phát triển do [SiliconFlow](https://siliconflow.cn/) cung cấp
+- UI dùng [Vue 3](https://vuejs.org/)
+
+---
+
+## Trợ giúp
+
+- 🐛 Báo lỗi: [GitHub Issues](https://github.com/qyzhg/prism/issues)
+
+---
+
+<div align="center">
+
+❤️ Phát triển bởi đội Prism@pity
+
+**[⬆ Lên đầu trang](#prism---phần-mềm-dịch-thuật-ai)**
+
+</div>

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**[中文](./README.zh.md) | [English](./README.md)**
+**[中文](./README.zh.md) | [English](./README.md) | [Español](./README.es.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md) | [Tiếng Việt](./README.vi.md)**
 
 🚀 一款强大的跨平台AI翻译应用，采用先进的语言模型和OCR技术。
 


### PR DESCRIPTION
I have added README files for 4 new languages based on the English version:

- Spanish (README.es.md)
- Korean (README.ko.md)
- Vietnamese (README.vi.md)
- Japanese (README.ja.md)

I also included the necessary macOS installation notes (Gatekeeper/signature bypass) and kept technical terms consistent.